### PR TITLE
Utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ ElmerGUI manual and tutorials
 * This repository includes the source files for building
   part of the Elmer doumentation.
 * Currently ElmerGUI Manual and Elmer Tutorials are provided.
-  The other parts of the domentation are yet not in open repository.
+  The other parts of the domentation are not yet in open repository.
 * The documentation here is licensed under Creative Commons
   Attribution-NonCommercial.
-* The documentation requires LaTex being installed. 
-* To create the documentaion under Linux you can say "source makedoc"
+* To build the documentation requires LaTex being installed. 
+* To create the documentation under Linux you can say "source makedoc"
 
 Content of the directories
 --------------------------
 * gui - ElmerGUI manual
 * tutorials-GUI - tutorials where ElmerGUI is used
-* tutorials-DL - tutorials without graphical user interfcace (command-line usage, files explained)
+* tutorials-CL - tutorials without graphical user interface (command-line usage, files explained)
 * tutorials-GUI-files - files related to GUI tutorials
 * tutorials-CL-files - files related to the tutorials wihout the graphical user interface 

--- a/tutorials-CL/ElmerTutorials-nonGUI.tex
+++ b/tutorials-CL/ElmerTutorials-nonGUI.tex
@@ -14,6 +14,8 @@
 
 \RequirePackage{hyperref}
 
+\UseRawInputEncoding
+
 \hypersetup{
     bookmarks=true,         % show bookmarks bar?
     unicode=false,          % non-Latin characters in Acrobat�s bookmarks

--- a/tutorials-GUI/ElmerTutorials.tex
+++ b/tutorials-GUI/ElmerTutorials.tex
@@ -14,6 +14,8 @@
 
 \RequirePackage{hyperref}
 
+\AddRawInputEncoding
+
 \hypersetup{
     bookmarks=true,         % show bookmarks bar?
     unicode=false,          % non-Latin characters in Acrobat�s bookmarks

--- a/tutorials-GUI/ElmerTutorials.tex
+++ b/tutorials-GUI/ElmerTutorials.tex
@@ -14,7 +14,7 @@
 
 \RequirePackage{hyperref}
 
-\AddRawInputEncoding
+\UseRawInputEncoding
 
 \hypersetup{
     bookmarks=true,         % show bookmarks bar?


### PR DESCRIPTION
This PR fixes this error:
[3 <./by-nc.png>]
! Package inputenc Error: Invalid UTF-8 byte "A0.
See the inputenc package documentation for explanation.

The PR has been tested with Ubuntu 20.04 LTS and Windows 10.
Also, a few spelling issues were fixed in the readme.md

