### PR TITLE
Minor typo corrections for elmerfem manuals.  Used the python program

### DIFF
--- a/elmergrid/elmergrid-commandline.tex
+++ b/elmergrid/elmergrid-commandline.tex
@@ -220,7 +220,7 @@ is given.
 \sifitem{-layermove}{int}
 This option activates a filter that applied the given number of times
 to map the node coordinates 
-so that the boundary layers are fittid to the original geometry.
+so that the boundary layers are fitted to the original geometry.
 %
 \sifitem{-3d / -2d / -1d}{}
 This option is usually not needed as the files most often have the information

--- a/latex-elmer-getstart/GetStartedElmer/GetStartedElmer.tex
+++ b/latex-elmer-getstart/GetStartedElmer/GetStartedElmer.tex
@@ -1094,7 +1094,7 @@ We want to force the location of the box to be at the origin.  Click on the thre
 \caption{Locate the box at the origin}\label{fg:gmsh-10}
 \end{figure}
 
-Let's set the size of the box to be DX = 300, DY = 200, and DZ = 200, by typing the numbers into the entry boxes, followed by clicking on `Add', as shown in Figure~\ref{fg:gmsh-11}.  Elmer uses SI units, (actually Elmer is unit-less, but in practical terms think of SI units as the active units in Elmer) so when running ElmerSolver these dimensions will be in meters.  You can scale the dimensions in Elmer, look up `Coordinate Scaling', which will allow one to easily convert from millimetres to meters.
+Let's set the size of the box to be DX = 300, DY = 200, and DZ = 200, by typing the numbers into the entry boxes, followed by clicking on `Add', as shown in Figure~\ref{fg:gmsh-11}.  Elmer uses SI units, (actually Elmer is unit-less, but in practical terms think of SI units as the active units in Elmer) so when running ElmerSolver these dimensions will be in meters.  You can scale the dimensions in Elmer, look up `Coordinate Scaling', which will allow one to easily convert from millimeters to meters.
 
 \begin{figure}[H]
 \centering
@@ -1450,7 +1450,7 @@ Below is a list of some of the most frequently asked questions. You can suggest 
 
     Q: What unit system should I use in Elmer?
 
-    A: Elmer does not assume any specific units so you can use any unit system that is consistent. The natural choice is SI units. By default the equations are scaled to an optimal range so usually there is no need for altering the unit system for the sake of numerical accuracy. However, if you choose, for example, your mesh to be in millimetres remember that it reflects to the units of velocity, density, force, viscosity etc., as well.\\
+    A: Elmer does not assume any specific units so you can use any unit system that is consistent. The natural choice is SI units. By default the equations are scaled to an optimal range so usually there is no need for altering the unit system for the sake of numerical accuracy. However, if you choose, for example, your mesh to be in millimeters remember that it reflects to the units of velocity, density, force, viscosity etc., as well.\\
 
     Q: I want to restart using the .ep result file, how do I do that?
 
@@ -1817,7 +1817,7 @@ ParaView uses C-Style numbering, beginning at 0 and ending at Number\_of\_nodes-
 
 \section{Crystal growth and phase change}
 
-One of the first applications of Elmer was the modelling of Czockralksi crystal growth. Many features have been developed this application in mind: Lagrangian phase change models, heat transfer via radiation, rotating coordinate system etc. Also Eulerian phase change models exist to account for tracking the phase change interface.\\
+One of the first applications of Elmer was the modelling of Czochralski crystal growth. Many features have been developed this application in mind: Lagrangian phase change models, heat transfer via radiation, rotating coordinate system etc. Also Eulerian phase change models exist to account for tracking the phase change interface.\\
 
 \noindent The most relevant solvers in the Models Manual include:\\
 

--- a/latex-elmergui/elmergui-appendix.tex
+++ b/latex-elmergui/elmergui-appendix.tex
@@ -70,7 +70,7 @@ The initialization file for ElmerGUI is located in {\tt ELMERGUI\_HOME/edf}. It 
 \end{verbatim}
 \end{footnotesize}
 
-You may change the default behavior of ElmerGUI by editing this file. For example, to turn off the splash screen at start up, change the value of the tag {\tt <splshscreen>} from 1 to 0. To change the background image, enter a picture file name in the {\tt <bgimagefile>} tag. You might also want to increase the default values for solvers, equations, etc., in case of very complex models.
+You may change the default behavior of ElmerGUI by editing this file. For example, to turn off the splash screen at start up, change the value of the tag {\tt <splashscreen>} from 1 to 0. To change the background image, enter a picture file name in the {\tt <bgimagefile>} tag. You might also want to increase the default values for solvers, equations, etc., in case of very complex models.
 
 \chapter{ElmerGUI material database}
 

--- a/latex-tutorials-CL/ArteryFlow/arteryflow.tex
+++ b/latex-tutorials-CL/ArteryFlow/arteryflow.tex
@@ -78,7 +78,7 @@ is to the midplane of the wall (inner radius + half of the wall thickness).
 The overall FSI iteration scheme is started by one dimensional solver
 ({\tt OutletCompute}, see the solver manual), after that Navier-Stokes, 
 elasticity and mesh update solvers are run.  Steady state convergence tolerance
-is set equalt to 1.0E-4 for each of the solvers.  The nonlinearities
+is set equal to 1.0E-4 for each of the solvers.  The nonlinearities
 of each of the solvers are computed within the FSI scheme loop, that is,
 the flag {\tt Nonlinear System Max Iterations} is set equal to 1.
 Artificial compressibility coefficient is computed by the equation

--- a/latex-tutorials-CL/CoatingProcess/coat.tex
+++ b/latex-tutorials-CL/CoatingProcess/coat.tex
@@ -248,7 +248,7 @@ free surface. To visualize the true free surface you may visualize the
 last timestep using Paraview, or some other software capable of reading
 VTU files. 
 %ead in the only the last timestep and in \texttt{ElmerPost} give the following
-%ommands:
+%commands:
 %ttbegin
 %ath nodes0 = nodes
 %ath nodes = nodes0 + Mesh.Update

--- a/latex-tutorials-CL/FlowStepIncompressible/flow_step.tex
+++ b/latex-tutorials-CL/FlowStepIncompressible/flow_step.tex
@@ -14,7 +14,7 @@
 A fluid, flowing past a step (see figure~\ref{fg:struct2}), has the density
 1~kg/m$³$ and viscosity 0.01~kg/ms. The velocity of the fluid on the 
 incoming boundary $\Gamma_6$ in the x-direction is 1~m/s and in 
-the y-direction 0~m/s (see figure~\ref{fg:struct2}). On the outcoming boundary 
+the y-direction 0~m/s (see figure~\ref{fg:struct2}). On the outgoing boundary 
 $\Gamma_4$ the velocity is 0~m/s in the y-direction and the pressure
 is 0~Pa. The problem is to solve the velocity field and the pressure 
 change in $\Omega$.

--- a/latex-tutorials-CL/FluidStructureBeam/Fsi.tex
+++ b/latex-tutorials-CL/FluidStructureBeam/Fsi.tex
@@ -12,9 +12,9 @@ in the region $\Omega_1$),
 see figure~\ref{fg:fsi}. The beam is 5.0~m long and it is rigidly 
 supported on the end $\Gamma_6$. At the incoming boundary $\Gamma_1$, the 
 fluid velocity in the x-direction is a parabola which reaches its 
-maximum value 1~m/s at the point y=5.0~m. At the incoming and outcoming 
+maximum value 1~m/s at the point y=5.0~m. At the incoming and outgoing 
 boundaries $\Gamma_1$ and $\Gamma_2$ velocities in the y-direction 
-are 0~m/s. At the outcoming boundary the pressure is 0~Pa. The velocities 
+are 0~m/s. At the outgoing boundary the pressure is 0~Pa. The velocities 
 on boundaries $\Gamma_3$, $\Gamma_4$ and $\Gamma_5$ are 0~m/s. The 
 fluid is incompressible and has density 1 kg/m$³$, dynamic 
 viscosity 0.5 kg/ms and Poisson ratio 0.3. Material properties 

--- a/latex-tutorials-CL/TemperatureOperatorSplitting/os-capability.tex
+++ b/latex-tutorials-CL/TemperatureOperatorSplitting/os-capability.tex
@@ -63,7 +63,7 @@ problem, respectively.
 The time-dependent Poisson equations can be solved using the basic heat 
 equation solver in Elmer. To avoid the use of stabilized finite element 
 formulations in the solution of the convective transport problem this 
-subproblem is solved by discretizating an equivalent wave-like equation 
+subproblem is solved by discretizing an equivalent wave-like equation 
 formulation (second order in time equation). 
   
 When the operator splitting method is applied,

--- a/latex-tutorials-CL/TemperatureRadiation/radiation.tex
+++ b/latex-tutorials-CL/TemperatureRadiation/radiation.tex
@@ -16,7 +16,7 @@ concentric cylinders is modeled.
 \subsection*{Solution Procedure}
 
 The problem is a pure heat transfer problem that may be solved
-with \texttt{HeatSolve}. The view and Gebharht factors 
+with \texttt{HeatSolve}. The view and Gebhart factors 
 associated with the radiation are solved as a first step 
 in solving the equations. Thereafter the nonlinear heat equation is solved
 until convergence is reached.

--- a/latex-tutorials-GUI/InductionHeatingGUI/InductionHeatingGUI.tex
+++ b/latex-tutorials-GUI/InductionHeatingGUI/InductionHeatingGUI.tex
@@ -255,7 +255,7 @@ efficiency is estimated to be 18.9~W. The corresponding results are shown
 in Fig.~\ref{fig:ind_heat1}.
 
 It can be noted that would the estimated heating efficiency be different from the known one
-the user may give the postpressing solver the \texttt{Desired Heating Power} in order to scale 
+the user may give the postprocessing solver the \texttt{Desired Heating Power} in order to scale 
 the potential of the solution. The solution, on the other hand, may be used as a source term 
 in heat equation, for example. 
 

--- a/matc/matc.tex
+++ b/matc/matc.tex
@@ -124,7 +124,7 @@ otherwise if they are of the same size or at least one of them is scalar, an ele
 \ttitem{l=a$|$b} elementwise logical or of a and b. 
 \ttitem{c=a?b} reduction: set values of a where b is zero to zero. 
 \ttitem{b=n m \% a} resize a to matrix of size n by m. 
-\ttitem{b=a} assing a to b. 
+\ttitem{b=a} assigning a to b. 
 \sifend
 
 
@@ -207,19 +207,19 @@ Execute commands from file given name.
 First form of the command gives list of available commands. Second form gives help on specific routine. 
 
 \ttitem{str = fread(fp,n)}
-Read n bytes from file given by fp. File pointer fp shoud have been obtained from a call to fopen or freopen, or be the standard input file stdin. Data is returned as function value.  \\
+Read n bytes from file given by fp. File pointer fp should have been obtained from a call to fopen or freopen, or be the standard input file stdin. Data is returned as function value.  \\
 SEE ALSO: fopen,freopen,fgets,fscanf,matcvt,cvtmat. 
 
 \ttitem{vec = fscanf(fp,fmt)}
-Read file fp as given in format. Format fmt is equal to C-language format. File pointer fp shoud have been obtained from a call to fopen or freopen, or be the standard input. \\
+Read file fp as given in format. Format fmt is equal to C-language format. File pointer fp should have been obtained from a call to fopen or freopen, or be the standard input. \\
 SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat. 
 
 \ttitem{str = fgets(fp)}
-Read next line from fp. File pointer fp shoud have been obtained from a call to fopen or freopen or be the standard input. \\ 
+Read next line from fp. File pointer fp should have been obtained from a call to fopen or freopen or be the standard input. \\ 
 SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat. 
 
 \ttitem{n = fwrite(fp,buf,n)}
-Write n bytes from buf to file fp. File pointer fp shoud have been obtained from a call to fopen or freopen or be the standard output (stdout) or standard error (stderr). Return value is number of bytes actually written. 
+Write n bytes from buf to file fp. File pointer fp should have been obtained from a call to fopen or freopen or be the standard output (stdout) or standard error (stderr). Return value is number of bytes actually written. 
 Note that one matrix element reserves 8 bytes of space. \\
 SEE ALSO: fopen,freopen,fputs,fprintf,matcvt,cvtmat. 
 


### PR DESCRIPTION
'scspell' to find words to correct.  https://github.com/myint/scspell